### PR TITLE
cobweb http requests should not include the fragment.

### DIFF
--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -74,9 +74,11 @@ class Cobweb
   end
 
   def get(url, options = @options)
-
     raise "url cannot be nil" if url.nil?
-    
+    uri = Addressable::URI.parse(url)
+    uri.fragment=nil
+    url = uri.to_s
+
     # get the unique id for this request
     unique_id = Digest::SHA1.hexdigest(url.to_s)
     if options.has_key?(:redirect_limit) and !options[:redirect_limit].nil?
@@ -100,8 +102,8 @@ class Cobweb
       content = deep_symbolize_keys(Marshal.load(redis.get(unique_id)))
     else
       # this url is valid for processing so lets get on with it
-      uri = Addressable::URI.parse(url.strip)
-      
+      #TODO the @http here is different from in head.  Should it be? - in head we are using a method-scoped variable.
+
       # retrieve data
       unless @http && @http.address == uri.host && @http.port == uri.inferred_port
         puts "Creating connection to #{uri.host}..." unless @options[:quiet]
@@ -125,7 +127,7 @@ class Cobweb
           puts "redirected... " unless @options[:quiet]
           
           # get location to redirect to
-          url = Addressable::URI.join(uri, response['location']).to_s
+          url = UriHelper.join_no_fragment(uri, response['location'])
           
           # decrement redirect limit
           redirect_limit = redirect_limit - 1
@@ -231,7 +233,10 @@ class Cobweb
   
   def head(url, options = @options)
     raise "url cannot be nil" if url.nil?    
-    
+    uri = Addressable::URI.parse(url.strip)
+    uri.fragment=nil
+    url = uri.to_s
+
     # get the unique id for this request
     unique_id = Digest::SHA1.hexdigest(url)
     if options.has_key?(:redirect_limit) and !options[:redirect_limit].nil?
@@ -255,8 +260,7 @@ class Cobweb
       content = deep_symbolize_keys(Marshal.load(redis.get("head-#{unique_id}")))
     else
       print "Retrieving #{url }... " unless @options[:quiet]
-      uri = Addressable::URI.parse(url.strip)
-      
+
       # retrieve data
       http = Net::HTTP.new(uri.host, uri.inferred_port)
       if uri.scheme == "https"
@@ -269,11 +273,12 @@ class Cobweb
       http.open_timeout = @options[:timeout].to_i
       
       begin      
-        response = http.head(uri.to_s)
-        
+        request = Net::HTTP::Head.new uri.request_uri
+        response = http.request request
+
         if @options[:follow_redirects] and response.code.to_i >= 300 and response.code.to_i < 400
           puts "redirected... " unless @options[:quiet]
-          url = Addressable::URI.parse(response['location']).to_s
+          url = UriHelper.join_no_fragment(uri, response['location'])
           redirect_limit = redirect_limit - 1
           options = options.clone
           options[:redirect_limit]=redirect_limit

--- a/lib/crawl_job.rb
+++ b/lib/crawl_job.rb
@@ -126,11 +126,12 @@ class CrawlJob
   def self.all_links_from_content(content)
     links = content[:links].keys.map{|key| content[:links][key]}.flatten
     links.reject!{|link| link.starts_with?("javascript:")}
-    links = links.map{|link| Addressable::URI.join(content[:url], link)}
+    links = links.map{|link| UriHelper.join_no_fragment(content[:url], link) }
     links.select!{|link| link.scheme == "http" || link.scheme == "https"}
+    links.uniq
     links
   end
-  
+
   def self.enqueue_content(content_request, link)
     new_request = content_request.clone
     new_request[:url] = link

--- a/lib/uri_helper.rb
+++ b/lib/uri_helper.rb
@@ -1,0 +1,8 @@
+class UriHelper
+  def self.join_no_fragment(content, link)
+    new_link = Addressable::URI.join(content, link)
+    new_link.fragment=nil
+    new_link
+  end
+
+end

--- a/spec/cobweb/cobweb_spec.rb
+++ b/spec/cobweb/cobweb_spec.rb
@@ -181,7 +181,29 @@ describe Cobweb do
           @cobweb.get(@base_url)[:response_time].should be_an_instance_of Float 
         end
       end
-      
     end
+    describe "location setting" do
+      it "Get should strip fragments" do
+        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP::Get.should_receive(:new).with("/")
+        @cobweb.get("http://www.google.com/#ignore")
+      end
+      it "head should strip fragments" do
+        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP::Head.should_receive(:new).with("/").and_return(@mock_http_request)
+        @cobweb.head("http://www.google.com/#ignore")
+      end
+      it "get should not strip path" do
+        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP::Get.should_receive(:new).with("/path/to/stuff")
+        @cobweb.get("http://www.google.com/path/to/stuff#ignore")
+      end
+      it "get should not strip query string" do
+        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP::Get.should_receive(:new).with("/path/to/stuff?query_string")
+        @cobweb.get("http://www.google.com/path/to/stuff?query_string#ignore")
+      end
+    end
+
   end  
 end 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,9 @@ RSpec.configure do |config|
     Net::HTTP::Get.stub!(:new).and_return(@mock_http_request)
     Net::HTTP::Get.stub!(:new).with("/redirect.html").and_return(@mock_http_redirect_request)
     Net::HTTP::Get.stub!(:new).with("/redirect2.html").and_return(@mock_http_redirect_request2)
-    
+
+    Net::HTTP::Head.stub!(:new).and_return(@mock_http_request)
+
     @mock_http_client.stub!(:request).with(@mock_http_request).and_return(@mock_http_response)
     @mock_http_client.stub!(:request).with(@mock_http_redirect_request).and_return(@mock_http_redirect_response)      
     @mock_http_client.stub!(:request).with(@mock_http_redirect_request2).and_return(@mock_http_redirect_response2)


### PR DESCRIPTION
Ensured that http requests do not include the fragment (section from the #).  Includes tests around cobweb to verify this.
