### PR TITLE
Change to ensure that utf8 content can be crawled.

### DIFF
--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -34,7 +34,7 @@ class Cobweb
   
   def initialize(options = {})
     @options = options
-    
+    default_use_encoding_safe_process_job_to  false
     default_follow_redirects_to               true
     default_redirect_limit_to                 10
     default_processing_queue_to               CobwebProcessJob

--- a/lib/encoding_safe_process_job.rb
+++ b/lib/encoding_safe_process_job.rb
@@ -1,0 +1,13 @@
+class EncodingSafeProcessJob
+
+  @queue = :encoding_safe_process_job
+
+  def self.perform(content)
+    clazz = const_get(content["processing_queue"])
+    content["body"] = Base64.decode64(content["body"])
+    clazz.perform(content)
+  end
+end
+
+
+


### PR DESCRIPTION
...ncode content before it is given to resque, wrapping the user specified processing_queue in a special queue named "encoding_safe_process_job", which will decode the content before giving it back to the processing_queue to handle.  Ensure that there is a encoding_safe_process_job worker started.
