### PR TITLE
Add missing config options, fix default values and layout

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -115,6 +115,8 @@ Creates a new crawler object based on a base_url
     ** :direct_call_process_job       - boolean that specifies whether objects should be passed directly to a processing method or should be put onto a queue
     ** :raise_exceptions              - defaults to handling exceptions with debug output, setting this to true will raise exceptions in your app
     ** :use_encoding_safe_process_job - Base64-encode the body when storing job in queue; set to true when you are expecting non-ASCII content (Default: false)
+    ** :proxy_addr                    - hostname of a proxy to use for crawling (e. g., 'myproxy.example.net', default: nil)
+    ** :proxy_port                    - port number of the proxy (default: nil)
     
     
 bc. crawler = Cobweb.new(:follow_redirects => false)

--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -60,6 +60,8 @@ class Cobweb
     default_valid_mime_types_to                ["*/*"]
     default_raise_exceptions_to               false
     default_store_inbound_links_to            false
+    default_proxy_addr_to                     nil
+    default_proxy_port_to                     nil
 
   end
   
@@ -154,7 +156,7 @@ class Cobweb
       # retrieve data
       #unless @http && @http.address == uri.host && @http.port == uri.inferred_port
         puts "Creating connection to #{uri.host}..." if @options[:debug]
-        @http = Net::HTTP.new(uri.host, uri.inferred_port)
+        @http = Net::HTTP.new(uri.host, uri.inferred_port, @options[:proxy_addr], @options[:proxy_port])
       #end
       if uri.scheme == "https"
         @http.use_ssl = true
@@ -327,7 +329,7 @@ class Cobweb
       # retrieve data
       unless @http && @http.address == uri.host && @http.port == uri.inferred_port
         puts "Creating connection to #{uri.host}..." unless @options[:quiet]
-        @http = Net::HTTP.new(uri.host, uri.inferred_port)
+        @http = Net::HTTP.new(uri.host, uri.inferred_port, @options[:proxy_addr], @options[:proxy_port])
       end
       if uri.scheme == "https"
         @http.use_ssl = true

--- a/spec/cobweb/cobweb_spec.rb
+++ b/spec/cobweb/cobweb_spec.rb
@@ -31,6 +31,8 @@ describe Cobweb do
     options[:timeout].should == 10
     options[:redis_options].should == {}
     options[:internal_urls].should == []
+    options[:proxy_addr].should be_nil
+    options[:proxy_port].should be_nil
     
   end
   
@@ -177,24 +179,32 @@ describe Cobweb do
     end
     describe "location setting" do
       it "Get should strip fragments" do
-        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP.should_receive(:new).with("www.google.com", 80, nil, nil)
         Net::HTTP::Get.should_receive(:new).with("/", @default_options)
         @cobweb.get("http://www.google.com/#ignore")
       end
       it "head should strip fragments" do
-        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP.should_receive(:new).with("www.google.com", 80, nil, nil)
         Net::HTTP::Head.should_receive(:new).with("/", {}).and_return(@mock_http_request)
         @cobweb.head("http://www.google.com/#ignore")
       end
       it "get should not strip path" do
-        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP.should_receive(:new).with("www.google.com", 80, nil, nil)
         Net::HTTP::Get.should_receive(:new).with("/path/to/stuff", @default_options)
         @cobweb.get("http://www.google.com/path/to/stuff#ignore")
       end
       it "get should not strip query string" do
-        Net::HTTP.should_receive(:new).with("www.google.com", 80)
+        Net::HTTP.should_receive(:new).with("www.google.com", 80, nil, nil)
         Net::HTTP::Get.should_receive(:new).with("/path/to/stuff?query_string", @default_options)
         @cobweb.get("http://www.google.com/path/to/stuff?query_string#ignore")
+      end
+    end
+    describe "with proxy" do
+      it "provides proxy parameters to Net::HTTP" do
+        cobweb = Cobweb.new proxy_addr: 'proxy.example.com', proxy_port: 1234
+        Net::HTTP.should_receive(:new).with("www.google.com", 80, "proxy.example.com", 1234)
+
+        cobweb.get("http://www.google.com/")
       end
     end
 


### PR DESCRIPTION
Hi, 
- I added two missing options (:crawl_finished_queue and :use_encoding_safe_process_job) to the list of Cobweb options because they're missing and I think they're quite important.
- I also clarified the default values for the two queue options: 1. they're strings, not class names and 2. they're different for sidekiq users.
- also added @s around the :valid_mime_types default value so it becomes properly visible on github (`*/*` on its own only emphasizes the slash). Might be reasonable to do this for all the symbols, but I didn't want to send a layout-only pull request.
  Frank
