### PR TITLE
Issue 29: Normalize URLs when storing inbound links

### DIFF
--- a/lib/cobweb_crawler.rb
+++ b/lib/cobweb_crawler.rb
@@ -122,7 +122,7 @@ class CobwebCrawler
 
             if @options[:store_inbound_links]
               document_links.each do |target_link|
-                target_uri = UriHelper.parse(target_link)
+                target_uri = UriHelper.parse(target_link).normalize
                 @redis.sadd("inbound_links_#{Digest::MD5.hexdigest(target_uri.to_s)}", UriHelper.parse(url).to_s)
               end
             end

--- a/lib/crawl.rb
+++ b/lib/crawl.rb
@@ -134,7 +134,7 @@ module CobwebModule
 
         if @options[:store_inbound_links]
           document_links.each do |link|
-            uri = URI.parse(link)
+            uri = URI.parse(link).normalize
             @redis.sadd("inbound_links_#{Digest::MD5.hexdigest(uri.to_s)}", url)
           end
         end

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -45,7 +45,7 @@ class Stats
   end
 
   def inbound_links_for(url)
-    uri = UriHelper.parse(url)
+    uri = UriHelper.parse(url).normalize
     @redis.smembers("inbound_links_#{Digest::MD5.hexdigest(uri.to_s)}")
   end
 


### PR DESCRIPTION
See: https://github.com/stewartmckee/cobweb/issues/29

I found that when scraping my site, I didn't see inbound links for URLs that had been changed by the normalization process.
