### PR TITLE
Proxy authentication while parsing url with Net::HTTP

### DIFF
--- a/lib/cobweb.rb
+++ b/lib/cobweb.rb
@@ -67,6 +67,14 @@ class Cobweb
 
   end
 
+  # This method will shift the proxies.
+  def proxy_shift(options = {})
+    @options[:proxy_addr] = options[:proxy_addr]
+    @options[:proxy_port] = options[:proxy_port]
+    @options[:proxy_uname] = options[:proxy_uname]
+    @options[:proxy_pwd] = options[:proxy_pwd]
+  end
+  
   # This method starts the resque based crawl and enqueues the base_url
   def start(base_url)
     raise ":base_url is required" unless base_url
@@ -158,7 +166,12 @@ class Cobweb
       # retrieve data
       #unless @http && @http.address == uri.host && @http.port == uri.inferred_port
         puts "Creating connection to #{uri.host}..." if @options[:debug]
-        @http = Net::HTTP.new(uri.host, uri.inferred_port, @options[:proxy_addr], @options[:proxy_port])
+        if @options[:proxy_uname] && @options[:proxy_pwd]
+          proxy = Net::HTTP::Proxy(@options[:proxy_addr], @options[:proxy_port], @options[:proxy_uname], @options[:proxy_pwd])
+          @http = proxy.start(uri.host, uri.inferred_port)
+        else
+          @http = Net::HTTP.new(uri.host, uri.inferred_port, @options[:proxy_addr], @options[:proxy_port])
+        end
       #end
       if uri.scheme == "https"
         @http.use_ssl = true
@@ -337,7 +350,12 @@ class Cobweb
       # retrieve data
       unless @http && @http.address == uri.host && @http.port == uri.inferred_port
         puts "Creating connection to #{uri.host}..." unless @options[:quiet]
-        @http = Net::HTTP.new(uri.host, uri.inferred_port, @options[:proxy_addr], @options[:proxy_port])
+        if @options[:proxy_uname] && @options[:proxy_pwd]
+          proxy = Net::HTTP::Proxy(@options[:proxy_addr], @options[:proxy_port], @options[:proxy_uname], @options[:proxy_pwd])
+          @http = proxy.start(uri.host, uri.inferred_port)
+        else
+          @http = Net::HTTP.new(uri.host, uri.inferred_port, @options[:proxy_addr], @options[:proxy_port])
+        end
       end
       if uri.scheme == "https"
         @http.use_ssl = true


### PR DESCRIPTION
I have added code in lib/cobweb.rb for authenticating proxies. Along with this i have added a feature to rotate proxies for each request, i.e "proxy_shift" method inside the 'Cobweb' class is used for easy shifting proxies.

Example for proxy shifting:
crawler = CobwebCrawler.new({:cache => xxx, :proxy_addr => 'xxxx', :proxy_port=> 'xxxx', :proxy_uname => 'xxxx', :proxy_pwd => 'xxxxx', :internal_urls => ["xxxxxxxx"]})
      
action = crawler.crawl("****url****") do |content|   
       
     # Below line changes proxies eachtime request for getting new url.
     crawler.proxy_shift({:proxy_addr => 'xxxx', :proxy_port=> 'xxxx', :proxy_uname => 'xxxx', :proxy_pwd => 'xxxx')
        
      # some-statements....
 end